### PR TITLE
Docs update for the PR #4352 Add acceleration constraints in the MPPI controller

### DIFF
--- a/configuration/packages/configuring-mppic.rst
+++ b/configuration/packages/configuring-mppic.rst
@@ -173,6 +173,50 @@ MPPI Parameters
   Description
     Maximum rotational velocity (rad/s).
 
+:ax_max:
+
+  ============== ===========================
+  Type           Default                    
+  -------------- ---------------------------
+  double         3.0 
+  ============== ===========================
+
+  Description
+    Maximum forward acceleration (m/s^2).
+
+:ay_max:
+
+  ============== ===========================
+  Type           Default                    
+  -------------- ---------------------------
+  double         3.0 
+  ============== ===========================
+
+  Description
+    Maximum lateral acceleration in either direction, if using ``Omni`` motion model (m/s^2).
+
+:ax_min:
+
+  ============== ===========================
+  Type           Default                    
+  -------------- ---------------------------
+  double         -3.0 
+  ============== ===========================
+
+  Description
+    Maximum deceleration along the X-axis (m/s^2).
+
+:az_max:
+
+  ============== ===========================
+  Type           Default                    
+  -------------- ---------------------------
+  double         3.5 
+  ============== ===========================
+
+  Description
+    Maximum angular acceleration (rad/s^2).
+
 :temperature:
 
   ============== ===========================
@@ -987,6 +1031,10 @@ Example
           vx_min: -0.35
           vy_max: 0.5
           wz_max: 1.9
+          ax_max: 3.0
+          ax_min: -3.0
+          ay_max: 3.0
+          az_max: 3.5
           iteration_count: 1
           prune_distance: 1.7
           transform_tolerance: 0.1

--- a/migration/Iron.rst
+++ b/migration/Iron.rst
@@ -356,3 +356,7 @@ Lifecycle Node: added bond_heartbeat_period parameter (and allow disabling the b
 Rotation Shim Controller: new parameter ``rotate_to_goal_heading``
 ******************************************************************
 `PR #4332 <https://github.com/ros-planning/navigation2/pull/4332>`_ introduces usage of parameter ``rotate_to_goal_heading`` for the rotation shim controller. It allows the rotation shim controller to take back control when reaching the XY goal tolerance to perform a clean rotation towards the goal heading. Some controllers will do this internally, but it is a useful option for others.
+
+MPPI Controller: Addition of acceleration constraints 
+******************************************************
+`PR #4352 <https://github.com/ros-navigation/navigation2/pull/4352>`_ adds new parameters ``ax_max``,``ax_min``,``ay_max``,``az_max`` for the MPPI controller. These parameters will enable the MPPI controller to generate local trajectories within the specified acceleration constraints.


### PR DESCRIPTION
docs update for new acceleration constraint parameters in the MPPI controller. 