### PR TITLE
Update docs to add velocity limit parameter in DWB Controller

### DIFF
--- a/configuration/packages/configuring-dwb-controller.rst
+++ b/configuration/packages/configuring-dwb-controller.rst
@@ -104,6 +104,7 @@ Example
           xy_goal_tolerance: 0.25
           trans_stopped_velocity: 0.25
           short_circuit_trajectory_evaluation: True
+          limit_vel_cmd_in_traj: False
           stateful: True
           critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
           BaseObstacle.scale: 0.02

--- a/configuration/packages/dwb-plugins/standard_traj_generator.rst
+++ b/configuration/packages/dwb-plugins/standard_traj_generator.rst
@@ -73,3 +73,14 @@ Parameters
     
     Description
         Whether to include the last pose in the trajectory.
+
+:``<dwb plugin>``.limit_vel_cmd_in_traj:
+
+  ==== =======
+  Type Default
+  ---- -------
+  bool false
+  ==== =======
+    
+    Description
+        Whether to limit velocity command in trajectory using current velocity.

--- a/migration/Jazzy.rst
+++ b/migration/Jazzy.rst
@@ -81,3 +81,13 @@ Before:
 After:
 
 .. image:: images/fix_flickering_visualization_after.png
+
+Option to limit velocity through DWB trajectory
+****************************
+
+In `PR #4663 <https://github.com/ros-navigation/navigation2/pull/4663>`_ a ``limit_vel_cmd_in_traj`` parameter was introduced to DWB local planner to allow the user to limit the velocity used in the trajectory generation based on the robot's current velocity.
+
+Default value: 
+
+- false
+


### PR DESCRIPTION
Update documentation to reflect changes in [PR#4663](https://github.com/ros-navigation/navigation2/pull/4663)

Related documentation:

- DWB plugins: standard trajectory generator
- Example configuration for DWB controller
- Migration guide from Jazzy to K-Turtle