### PR TITLE
Update writing_new_costmap2d_plugin.rst

### DIFF
--- a/plugin_tutorials/docs/writing_new_costmap2d_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_costmap2d_plugin.rst
@@ -230,6 +230,7 @@ In this case each plugin object will be handled by its own parameters tree in a 
     plugin: nav2_gradient_costmap_plugin::GradientLayer # In Iron and older versions, "/" was used instead of "::"
     enabled: False
     ...
+NOTE: the order in which plugins are listed in the configuration is significant, as it determines the sequence in which they are applied to the costmap. For example, if the inflation layer is listed before the range layer, obstacles added to the costmap by the range layer will not be inflated.
 
 4- Run GradientLayer plugin
 ---------------------------


### PR DESCRIPTION
Order of plugins in plugins list has significance. This was one of the insights I got from spending considerable time troubleshooting inflation error I got when I added range layer. Hoping henceforth this piece of insight will help new user. Please do let me know if this is explicitly mentioned elsewhere in the documentation.