### PR TITLE
fix parameter name to enable_stamped_cmd_vel

### DIFF
--- a/migration/Jazzy.rst
+++ b/migration/Jazzy.rst
@@ -13,7 +13,7 @@ it also allows for rejection of stale velocity messages, which can be useful in 
 Your robot should now subscribe to a ``TwistStamped`` message instead of a ``Twist`` message & update your simulation appropriately.
 The topic names are the same.
 
-However, this can be disabled by setting ``enable_twist_stamped`` to ``false`` in the ``nav2_params.yaml`` file for all nodes that involve Twist subscriptions or publications.
+However, this can be disabled by setting ``enable_stamped_cmd_vel`` to ``false`` in the ``nav2_params.yaml`` file for all nodes that involve Twist subscriptions or publications.
 See the configuration guide for more information on how to configure this parameter for each node.
 
 An example simulation migration using Gazebo can be seen in the `following pull request for the Turtlebot 3 and 4 <https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation/pull/16>`_.


### PR DESCRIPTION
The actual name everywhere else in the documentation is `enable_stamped_cmd_vel` and that is what works on current rolling as well.