### PR TITLE
fix typo in bash code block 

### DIFF
--- a/tutorials/docs/docker_dev.rst
+++ b/tutorials/docs/docker_dev.rst
@@ -190,7 +190,7 @@ Now we can do something fun while we have both terminals of the same docker cont
 
 .. code-block:: bash
 
-	ros2 run ros2 run demo_nodes_cpp talker
+	ros2 run demo_nodes_cpp talker
 	ros2 run demo_nodes_py listener
 
 ------------


### PR DESCRIPTION
This pull request includes a small change to the `tutorials/docs/docker_dev.rst` file. The change corrects a redundant command in the bash code block.