### PR TITLE
Add note about multi-robot launch file changes

### DIFF
--- a/migration/Jazzy.rst
+++ b/migration/Jazzy.rst
@@ -214,3 +214,8 @@ In `PR #4795 <https://github.com/ros-navigation/navigation2/pull/4795>`_ the ``n
 * Automatic creation of orientations for the plan if they are missing.
 * Addition of ``v_angular_min_in_place`` parameter to avoid the robot getting stuck while rotating due to mechanical limitations.
 * ``final_rotation`` has been renamed ``prefer_final_rotation`` and the behavior has changed slightly.
+
+Conform to ROS 2 launch syntax in Turtlebot 3 multi-robot launch file
+*********************************************************************
+
+In `PR #4811 <https://github.com/ros-navigation/navigation2/pull/4811>`_ the ``cloned_multi_tb3_simulation_launch.py`` launch file was updated so that parsing the robots conforms to the ROS 2 launch file standards. This was achieved by refactoring the ``ParseMultiRobotPose`` class to be a custom launch substitution. This change allows users to pass the ``robots`` from another launch file through ``launch_arguments`` which was not possible with the old version.

--- a/migration/Jazzy.rst
+++ b/migration/Jazzy.rst
@@ -219,3 +219,14 @@ Conform to ROS 2 launch syntax in Turtlebot 3 multi-robot launch file
 *********************************************************************
 
 In `PR #4811 <https://github.com/ros-navigation/navigation2/pull/4811>`_ the ``cloned_multi_tb3_simulation_launch.py`` launch file was updated so that parsing the robots conforms to the ROS 2 launch file standards. This was achieved by refactoring the ``ParseMultiRobotPose`` class to be a custom launch substitution. This change allows users to pass the ``robots`` from another launch file through ``launch_arguments`` which was not possible with the old version.
+
+Example for including ``cloned_multi_tb3_simulation_launch.py`` in another launch file:
+
+.. code-block:: python
+
+    IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(get_package_share_directory('nav2_bringup'), "launch", "cloned_multi_tb3_simulation_launch.py")
+        ),
+        launch_arguments={"robots": "robot1={x: 0.5, y: 0.5, yaw: 1.5707}"}.items(),
+    )


### PR DESCRIPTION
Documentation changes for https://github.com/ros-navigation/navigation2/pull/4811.

Should I add an example of what was the problem with the original parsing namely that something like the following didn't work as expected:
```python
IncludeLaunchDescription(
    PythonLaunchDescriptionSource(
        os.path.join(get_package_share_directory('nav2_bringup'), "launch", "cloned_multi_tb3_simulation_launch.py")
    ),
    launch_arguments={"robots": "robot1={x: 0.5, y: 0.5, yaw: 1.5707}"}.items(),
)
```

or is this not relevant for the documentation?