### PR TITLE
Documentation for acceleration limits in DriveOnHeading and BackUp behaviors

### DIFF
--- a/configuration/packages/configuring-behavior-server.rst
+++ b/configuration/packages/configuring-behavior-server.rst
@@ -302,7 +302,7 @@ Backup distance, speed and time_allowance is given from the action request.
   ============== =============================
 
   Description
-    Minimum speed (m/s). Positive value.
+    Minimum speed to move, the deadband velocity of the robot behavior (m/s). Positive value.
 
 DriveOnHeading Behavior Parameters
 **********************************
@@ -375,7 +375,7 @@ DriveOnHeading distance, speed and time_allowance is given from the action reque
   ============== =============================
 
   Description
-    Minimum speed (m/s).
+    Minimum speed to move, the deadband velocity of the robot behavior (m/s). Positive value.
 
 AssistedTeleop Behavior Parameters
 **********************************

--- a/configuration/packages/configuring-behavior-server.rst
+++ b/configuration/packages/configuring-behavior-server.rst
@@ -280,7 +280,7 @@ Backup distance, speed and time_allowance is given from the action request.
   ============== =============================
 
   Description
-    Maximum acceleration limit (m/s^2). This effects the speed decreasing of the robot as we move backwards.
+    Maximum acceleration limit (m/s^2). This parameter limits the rate at which speed increases when moving backward.
 
 :backup.deceleration_limit:
 
@@ -291,7 +291,7 @@ Backup distance, speed and time_allowance is given from the action request.
   ============== =============================
 
   Description
-    Maximum deceleration limit (m/s^2). Negative value. This effects the speed increasing of the robot as we move backwards.
+    Maximum deceleration limit (m/s^2). Negative value. This parameter limits the rate at which speed decreases when moving backward.
 
 :backup.minimum_speed:
 

--- a/configuration/packages/configuring-behavior-server.rst
+++ b/configuration/packages/configuring-behavior-server.rst
@@ -271,6 +271,39 @@ Backup distance, speed and time_allowance is given from the action request.
     True uses TwistStamped, false uses Twist.
     Note: This parameter is default ``false`` in Jazzy or older! Kilted or newer uses ``TwistStamped`` by default.
 
+:backup.acceleration_limit:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  double         2.5
+  ============== =============================
+
+  Description
+    Maximum acceleration limit (m/s^2). This effects the speed decreasing of the robot as we move backwards.
+
+:backup.deceleration_limit:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  double         -2.5
+  ============== =============================
+
+  Description
+    Maximum deceleration limit (m/s^2). Negative value. This effects the speed increasing of the robot as we move backwards.
+
+:backup.minimum_speed:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  double         0.10
+  ============== =============================
+
+  Description
+    Minimum speed (m/s). Positive value.
+
 DriveOnHeading Behavior Parameters
 **********************************
 
@@ -310,6 +343,39 @@ DriveOnHeading distance, speed and time_allowance is given from the action reque
 
   Description
     The lifecycle node bond mechanism publishing period (on the /bond topic). Disabled if inferior or equal to 0.0.
+
+:drive_on_heading.acceleration_limit:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  double         2.5
+  ============== =============================
+
+  Description
+    Maximum acceleration limit (m/s^2).
+
+:drive_on_heading.deceleration_limit:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  double         -2.5
+  ============== =============================
+
+  Description
+    Maximum deceleration limit (m/s^2). Negative value.
+
+:drive_on_heading.minimum_speed:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  double         0.10
+  ============== =============================
+
+  Description
+    Minimum speed (m/s).
 
 AssistedTeleop Behavior Parameters
 **********************************

--- a/migration/Jazzy.rst
+++ b/migration/Jazzy.rst
@@ -255,7 +255,7 @@ In the `PR #4621 <https://github.com/ros-navigation/navigation2/pull/4621>`_ MPP
 MPPI Optimizer's performance is improved by 40-50%. Now MPPI Controller can also be run on ARM processors which do not support SIMD Instructions extensively. 
 
 DriveOnHeading and BackUp behaviors: Addition of acceleration constraints
-******************************************************************
+*************************************************************************
 `PR #4810 <https://github.com/ros-navigation/navigation2/pull/4810>`_ adds new parameters ``acceleration_limit``, ``deceleration_limit``, ``minimum_speed`` for the `DriveOnHeading` and `BackUp` Behaviors. The default values are as follows:
 
 - ``acceleration_limit``: 2.5

--- a/migration/Jazzy.rst
+++ b/migration/Jazzy.rst
@@ -253,3 +253,11 @@ MPPI controller re-implemented using Eigen library and performance improved by 4
 
 In the `PR #4621 <https://github.com/ros-navigation/navigation2/pull/4621>`_ MPPI controller is fully reimplemented using Eigen as it is well supported hpc library and suits better for our use case of two dimensional batches of trajectories. GPU support for rolling out trajectories could also be possible in future using Eigen.
 MPPI Optimizer's performance is improved by 40-50%. Now MPPI Controller can also be run on ARM processors which do not support SIMD Instructions extensively. 
+
+DriveOnHeading and BackUp behaviors: Addition of acceleration constraints
+******************************************************************
+`PR #4810 <https://github.com/ros-navigation/navigation2/pull/4810>`_ adds new parameters ``acceleration_limit``, ``deceleration_limit``, ``minimum_speed`` for the `DriveOnHeading` and `BackUp` Behaviors. The default values are as follows:
+
+- ``acceleration_limit``: 2.5
+- ``deceleration_limit``: -2.5
+- ``minimum_speed``: 0.10


### PR DESCRIPTION
New docs for params introduced by PR https://github.com/ros-navigation/navigation2/pull/4810.