### PR TITLE
Documentation for Rotation Shim Deceleration feature

### DIFF
--- a/migration/Jazzy.rst
+++ b/migration/Jazzy.rst
@@ -253,3 +253,25 @@ MPPI controller re-implemented using Eigen library and performance improved by 4
 
 In the `PR #4621 <https://github.com/ros-navigation/navigation2/pull/4621>`_ MPPI controller is fully reimplemented using Eigen as it is well supported hpc library and suits better for our use case of two dimensional batches of trajectories. GPU support for rolling out trajectories could also be possible in future using Eigen.
 MPPI Optimizer's performance is improved by 40-50%. Now MPPI Controller can also be run on ARM processors which do not support SIMD Instructions extensively. 
+
+Rotation Shim Deceleration as a function of its target orientation
+**************************************************************************
+
+In `PR #4864 <https://github.com/ros-navigation/navigation2/pull/4864>`_ the Rotation Shim Controller was updated to decelerate as a function of its target orientation. This allows the robot to slow down as it approaches its target orientation, reducing overshoot when passing to the primary controller. The deceleration is controlled by the `max_angular_accel` parameter.
+
+A demo can be seen below with the following parameters:
+
+.. code-block:: yaml
+
+  [...]:
+    plugin: "nav2_rotation_shim_controller::RotationShimController"
+    angular_dist_threshold: 1.22 # (70 degrees)
+    angular_disengage_threshold: 0.05 # (3 degrees)
+    rotate_to_heading_angular_vel: 0.8
+    max_angular_accel: 0.5
+
+
+.. image:: images/rotation_shim_decel.gif
+  :width: 800
+  :alt: Rotation Shim Deceleration
+  :align: center


### PR DESCRIPTION
Added migration guide entry for the new rotation shim decelearation (PR https://github.com/ros-navigation/navigation2/pull/4864).