### PR TITLE
Fix example syntax for the AreErrorCodesPresent BT node

### DIFF
--- a/configuration/packages/bt-plugins/conditions/AreErrorCodesPresent.rst
+++ b/configuration/packages/bt-plugins/conditions/AreErrorCodesPresent.rst
@@ -45,4 +45,4 @@ Error codes to check are defined to be 101, 107 and 119.
 
 .. code-block:: xml
 
-    <AreErrorCodesPresent error_code="{error_code}" error_codes_to_check="101,107,119"/>
+    <AreErrorCodesPresent error_code="{error_code}" error_codes_to_check="101;107;119"/>


### PR DESCRIPTION
In behavior trees, lists provided as parameters must be semicolon-separated, and not comma-separated. Source: https://github.com/BehaviorTree/BehaviorTree.CPP/blob/master/src/basic_types.cpp#L217