### PR TITLE
Migrate `geometry_msgs/PoseStampedArray` to `nav_msgs/Goals`

### DIFF
--- a/configuration/packages/bt-plugins/actions/ComputePathThroughPoses.rst
+++ b/configuration/packages/bt-plugins/actions/ComputePathThroughPoses.rst
@@ -23,11 +23,11 @@ Input Ports
 
 :goals:
 
-  ===================================== =======
-  Type                                  Default
-  ------------------------------------- -------
-  geometry_msgs::msg::PoseStampedArray    N/A  
-  ===================================== =======
+  ==================== =======
+  Type                 Default
+  -------------------- -------
+  nav_msgs::msg::Goals   N/A
+  ==================== =======
 
   Description
     	Goal poses. Takes in a blackboard variable, e.g. "{goals}".

--- a/configuration/packages/bt-plugins/actions/NavigateThroughPoses.rst
+++ b/configuration/packages/bt-plugins/actions/NavigateThroughPoses.rst
@@ -12,11 +12,11 @@ Input Ports
 
 :goals:
 
-  ==================================== =======
-  Type                                 Default
-  ------------------------------------ -------
-  geometry_msgs::msg::PoseStampedArray   N/A
-  ==================================== =======
+  ==================== =======
+  Type                 Default
+  -------------------- -------
+  nav_msgs::msg::Goals   N/A
+  ==================== =======
 
   Description
       Goal poses. Takes in a blackboard variable, e.g. "{goals}".

--- a/configuration/packages/bt-plugins/actions/RemoveInCollisionGoals.rst
+++ b/configuration/packages/bt-plugins/actions/RemoveInCollisionGoals.rst
@@ -22,11 +22,11 @@ Input Ports
 
 :input_goals:
 
-  ==================================== =======
-  Type                                 Default
-  ------------------------------------ -------
-  geometry_msgs::msg::PoseStampedArray   N/A  
-  ==================================== =======
+  ==================== =======
+  Type                 Default
+  -------------------- -------
+  nav_msgs::msg::Goals   N/A
+  ==================== =======
 
   Description
     A vector of goals to check if in collision

--- a/configuration/packages/bt-plugins/actions/RemovePassedGoals.rst
+++ b/configuration/packages/bt-plugins/actions/RemovePassedGoals.rst
@@ -33,11 +33,11 @@ Input Ports
 
 :input_goals:
 
-  ==================================== =======
-  Type                                 Default
-  ------------------------------------ -------
-  geometry_msgs::msg::PoseStampedArray   N/A  
-  ==================================== =======
+  ==================== =======
+  Type                 Default
+  -------------------- -------
+  nav_msgs::msg::Goals   N/A
+  ==================== =======
 
   Description
     A vector of goals to check if it passed any in the current iteration.
@@ -47,11 +47,11 @@ Output Ports
 
 :output_goals:
 
-  ==================================== =======
-  Type                                 Default
-  ------------------------------------ -------
-  geometry_msgs::msg::PoseStampedArray   N/A  
-  ==================================== =======
+  ==================== =======
+  Type                 Default
+  -------------------- -------
+  nav_msgs::msg::Goals   N/A
+  ==================== =======
 
   Description
     A vector of goals with goals removed in proximity to the robot

--- a/configuration/packages/bt-plugins/conditions/GlobalUpdatedGoal.rst
+++ b/configuration/packages/bt-plugins/conditions/GlobalUpdatedGoal.rst
@@ -25,11 +25,11 @@ Input Ports
 
 :goals:
 
-  ==================================== =========
-  Type                                 Default
-  ------------------------------------ ---------
-  geometry_msgs::msg::PoseStampedArray "{goals}"
-  ==================================== =========
+  ==================== =========
+  Type                 Default
+  -------------------- ---------
+  nav_msgs::msg::Goals "{goals}"
+  ==================== =========
 
   Description
     	Vector of goals to check. Takes in a blackboard variable, "{goals}" if not specified.

--- a/configuration/packages/bt-plugins/conditions/GoalUpdated.rst
+++ b/configuration/packages/bt-plugins/conditions/GoalUpdated.rst
@@ -22,11 +22,11 @@ Input Ports
 
 :goals:
 
-  ==================================== =========
-  Type                                 Default
-  ------------------------------------ ---------
-  geometry_msgs::msg::PoseStampedArray "{goals}"
-  ==================================== =========
+  ==================== =========
+  Type                 Default
+  -------------------- ---------
+  nav_msgs::msg::Goals "{goals}"
+  ==================== =========
 
   Description
     	Vector of goals to check. Takes in a blackboard variable, "{goals}" if not specified.

--- a/configuration/packages/bt-plugins/decorators/GoalUpdatedController.rst
+++ b/configuration/packages/bt-plugins/decorators/GoalUpdatedController.rst
@@ -21,11 +21,11 @@ Input Ports
 
 :goals:
 
-  ==================================== =========
-  Type                                 Default
-  ------------------------------------ ---------
-  geometry_msgs::msg::PoseStampedArray "{goals}"
-  ==================================== =========
+  ==================== =========
+  Type                 Default
+  -------------------- ---------
+  nav_msgs::msg::Goals "{goals}"
+  ==================== =========
 
   Description
     	Vector of goals to check. Takes in a blackboard variable, "{goals}" if not specified.

--- a/configuration/packages/bt-plugins/decorators/GoalUpdater.rst
+++ b/configuration/packages/bt-plugins/decorators/GoalUpdater.rst
@@ -46,11 +46,11 @@ Input Ports
 
 :input_goals:
 
-  ============================== =======
-  Type                           Default
-  ------------------------------ -------
-  geometry_msgs/PoseStampedArray   N/A
-  ============================== =======
+  ============== =======
+  Type           Default
+  -------------- -------
+  nav_msgs/Goals   N/A
+  ============== =======
 
   Description
       The original goals poses
@@ -70,13 +70,13 @@ Output Ports
     	The resulting updated goal. If no goal received by subscription, it will be the input_goal
 
 :output_goals:
-  
-    ============================== =======
-    Type                           Default
-    ------------------------------ -------
-    geometry_msgs/PoseStampedArray   N/A
-    ============================== =======
-  
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  nav_msgs/Goals   N/A
+  ============== =======
+
     Description
       	The resulting updated goals. If no goals received by subscription, it will be the input_goals
 

--- a/configuration/packages/bt-plugins/decorators/SpeedController.rst
+++ b/configuration/packages/bt-plugins/decorators/SpeedController.rst
@@ -68,11 +68,11 @@ Input Ports
 
 :goals:
 
-  ==================================== =========
-  Type                                 Default
-  ------------------------------------ ---------
-  geometry_msgs::msg::PoseStampedArray "{goals}"
-  ==================================== =========
+  ==================== =========
+  Type                 Default
+  -------------------- ---------
+  nav_msgs::msg::Goals "{goals}"
+  ==================== =========
 
   Description
     	Vector of goals to check. Takes in a blackboard variable, "{goals}" if not specified.

--- a/migration/Jazzy.rst
+++ b/migration/Jazzy.rst
@@ -302,12 +302,12 @@ Example for including ``cloned_multi_tb3_simulation_launch.py`` in another launc
         launch_arguments={"robots": "robot1={x: 0.5, y: 0.5, yaw: 1.5707}"}.items(),
     )
 
-ComputePathThroughPoses, NavigateThroughPoses and other BT nodes now use PoseStampedArray instead of vector<PoseStamped>
+ComputePathThroughPoses, NavigateThroughPoses and other BT nodes now use nav_msgs/Goals instead of vector<PoseStamped>
 ************************************************************************************************************************
 
-In `PR #262 <https://github.com/ros2/common_interfaces/pull/262>`_ a new message type `PoseStampedArray` was introduced to the `geometry_msgs` package.
-In `PR #4791 <https://github.com/ros-navigation/navigation2/pull/4791>`_, most instances of `std::vector<geometry_msgs::msg::PoseStamped>` have been replaced with `geometry_msgs::msg::PoseStampedArray`. Most notably, `NavigateThroughPoses.action` and `ComputePathThroughPoses.action` have been updated to use `PoseStampedArray`.
-Since `PoseStampedArray` contains a header, the poses are now accessed via `NavigateThroughPoses.poses.poses` instead of `NavigateThroughPoses.poses` or `ComputePathThroughPoses.goals.poses` instead of `ComputePathThroughPoses.poses`. Please update your code accordingly when using these interfaces.
+In `PR #269 <https://github.com/ros2/common_interfaces/pull/269>`_ a new message type `Goals` was introduced to the `nav_msgs` package.
+In `PR #4980 <https://github.com/ros-navigation/navigation2/pull/4980>`_, all collections of `PoseStamped` has been migrated to use the `nav_msgs::msg::Goals` message. Most notably, `NavigateThroughPoses.action` and `ComputePathThroughPoses.action` have been updated to use `nav_msgs/Goals`.
+Since `nav_msgs/Goals` contains a header, the poses are now accessed via `NavigateThroughPoses.poses.goals` instead of `NavigateThroughPoses.poses` or `ComputePathThroughPoses.goals.goals` instead of `ComputePathThroughPoses.poses`. Please update your code accordingly when using these interfaces.
 
 MPPI controller re-implemented using Eigen library and performance improved by 40-45%
 *************************************************************************************


### PR DESCRIPTION
## Description
This modifies the documentation to handle the migration of `geometry_msgs/PoseStamped` to `nav_msgs/Goals` in https://github.com/ros-navigation/navigation2/pull/4980.

## Testing
The following changes have been verified using `make html` and opening the `_build/html/index.html` file on a browser window.