### PR TITLE
Migrate multi robot launch to use updated robot string syntax.

### DIFF
--- a/migration/Jazzy.rst
+++ b/migration/Jazzy.rst
@@ -289,7 +289,7 @@ In `PR #4795 <https://github.com/ros-navigation/navigation2/pull/4795>`_ the ``n
 Conform to ROS 2 launch syntax in Turtlebot 3 multi-robot launch file
 *********************************************************************
 
-In `PR #4811 <https://github.com/ros-navigation/navigation2/pull/4811>`_ the ``cloned_multi_tb3_simulation_launch.py`` launch file was updated so that parsing the robots conforms to the ROS 2 launch file standards. This was achieved by refactoring the ``ParseMultiRobotPose`` class to be a custom launch substitution. This change allows users to pass the ``robots`` from another launch file through ``launch_arguments`` which was not possible with the old version.
+In `PR #5000 <https://github.com/ros-navigation/navigation2/pull/5000>`_ the ``cloned_multi_tb3_simulation_launch.py`` launch file was updated so that parsing the robots conforms to the ROS 2 launch file standards. This change allows users to pass the ``robots`` from another launch file through ``launch_arguments`` which was not possible with the old version.
 
 Example for including ``cloned_multi_tb3_simulation_launch.py`` in another launch file:
 
@@ -299,7 +299,7 @@ Example for including ``cloned_multi_tb3_simulation_launch.py`` in another launc
         PythonLaunchDescriptionSource(
             os.path.join(get_package_share_directory('nav2_bringup'), "launch", "cloned_multi_tb3_simulation_launch.py")
         ),
-        launch_arguments={"robots": "robot1={x: 0.5, y: 0.5, yaw: 1.5707}"}.items(),
+        launch_arguments={"robots": "{name: 'robot1', pose: {x: 0.5, y: 0.5, yaw: 1.5707}}"}.items(),
     )
 
 ComputePathThroughPoses, NavigateThroughPoses and other BT nodes now use nav_msgs/Goals instead of vector<PoseStamped>


### PR DESCRIPTION
## Description
This modifies the documentation to handle the deprecation of `ParseMultiRobotPose` in https://github.com/ros-navigation/navigation2/pull/5000.

## Testing
The following changes have been verified using `make html` and opening the `_build/html/index.html` file on a browser window.