### PR TITLE
Minor changes in Planner, Controller, Smoother, Route and Behaviour Servers in Navigation Concepts

### DIFF
--- a/concepts/index.rst
+++ b/concepts/index.rst
@@ -110,7 +110,7 @@ In this section, the general concepts around them and their uses in this project
 Planner, Controller, Smoother, Route, and Behavior Servers
 ==========================================================
 
-Four of the action servers in this project are the planner, behavior, smoother, route, and controller servers.
+Five of the action servers in this project are the planner, behavior, smoother, route, and controller servers.
 
 These action servers are used to host a map of algorithm plugins to complete various tasks.
 They also host the environmental representation used by the algorithm plugins to compute their outputs.


### PR DESCRIPTION
 Changed from Four to Five in representing action servers.

Note:
    While I was reading through the documentation I found this blunder. I don't know, if that was on purpose or really a blunder, if it is you can merge this or close this request.
