### PR TITLE
Add documentation for ClearCostmapAroundPose BT action node

### DIFF
--- a/commander_api/index.rst
+++ b/commander_api/index.rst
@@ -132,6 +132,15 @@ New as of September 2023: the simple navigator constructor will accept a `namesp
 +---------------------------------------+----------------------------------------------------------------------------+
 | clearGlobalCostmap()                  | Clears the global costmap.                                                 |
 +---------------------------------------+----------------------------------------------------------------------------+
+| clearLocalCostmapAroundPose(          |                                                                            |
+| PoseStamped, distance)                | Clears the local costmap around given pose.                                |
++---------------------------------------+----------------------------------------------------------------------------+
+| clearGlobalCostmapAroundPose(         |                                                                            |
+| PoseStamped, distance)                | Clears the global costmap around given pose.                               |
++---------------------------------------+----------------------------------------------------------------------------+
+| clearCostmapExceptRegion(             |                                                                            |
+| distance)                             | Clears the local costmap around current robot pose.                        |
++---------------------------------------+----------------------------------------------------------------------------+
 | getGlobalCostmap()                    | Returns the global costmap, ``nav2_msgs/Costmap``.                         |
 +---------------------------------------+----------------------------------------------------------------------------+
 | getLocalCostmap()                     | Returns the local costmap, ``nav2_msgs/Costmap``.                          |

--- a/configuration/packages/bt-plugins/actions/ClearCostmapAroundPose.rst
+++ b/configuration/packages/bt-plugins/actions/ClearCostmapAroundPose.rst
@@ -58,7 +58,7 @@ Example
 
 .. code-block:: xml
 
-  <ClearCostmapAroundPose name="ClearLocalCostmapAroundPose" 
-                          service_name="local_costmap/clear_around_pose_local_costmap" 
-                          pose="{goal_pose}" 
+  <ClearCostmapAroundPose name="ClearLocalCostmapAroundPose"
+                          service_name="local_costmap/clear_around_pose_local_costmap"
+                          pose="{goal_pose}"
                           reset_distance="2.0"/>

--- a/configuration/packages/bt-plugins/actions/ClearCostmapAroundPose.rst
+++ b/configuration/packages/bt-plugins/actions/ClearCostmapAroundPose.rst
@@ -1,0 +1,64 @@
+.. _bt_clear_costmap_around_pose_action:
+
+
+ClearCostmapAroundPose
+======================
+
+Action to call a costmap clearing around a given pose server.
+
+Input Ports
+-----------
+
+:pose:
+
+  =============================== =======
+  Type                            Default
+  ------------------------------- -------
+  geometry_msgs::msg::PoseStamped N/A
+  =============================== =======
+
+  Description
+    	Pose around which to clear the costmap
+
+:reset_distance:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  double         1.0
+  ============== =======
+
+  Description
+    	Distance from the pose under which obstacles are cleared
+
+:service_name:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  string         N/A
+  ============== =======
+
+  Description
+    	costmap service name responsible for clearing the costmap.
+
+:server_timeout:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  double         10
+  ============== =======
+
+  Description
+    	Action server timeout (ms).
+
+Example
+-------
+
+.. code-block:: xml
+
+  <ClearCostmapAroundPose name="ClearLocalCostmapAroundPose" 
+                          service_name="local_costmap/clear_around_pose_local_costmap" 
+                          pose="{goal_pose}" 
+                          reset_distance="2.0"/>

--- a/configuration/packages/configuring-bt-xml.rst
+++ b/configuration/packages/configuring-bt-xml.rst
@@ -32,6 +32,7 @@ Action Plugins
   bt-plugins/actions/ClearEntireCostmap.rst
   bt-plugins/actions/ClearCostmapExceptRegion.rst
   bt-plugins/actions/ClearCostmapAroundRobot.rst
+  bt-plugins/actions/ClearCostmapAroundPose.rst
   bt-plugins/actions/ReinitializeGlobalLocalization.rst
   bt-plugins/actions/TruncatePath.rst
   bt-plugins/actions/TruncatePathLocal.rst


### PR DESCRIPTION
Add documentation for the new ClearCostmapAroundPose BT action node introduced in ros-navigation/navigation2 PR #5309.

- Add ClearCostmapAroundPose.rst documentation file following established patterns
- Add entry to configuring-bt-xml.rst table of contents
- Documents new BT action that clears costmap around a specific pose

Closes #714

Generated with [Claude Code](https://claude.ai/code)