### PR TITLE
docs: add subscribe_to_stamped_footprint parameter to costmap 2d configuration guide

### DIFF
--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -200,6 +200,17 @@ Costmap2D ROS Parameters
   Description
     Robot radius to use, if footprint coordinates not provided. If this parameter is set, ``isPathValid`` will do circular collision checking.
 
+:subscribe_to_stamped_footprint:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  bool           False
+  ============== =======
+
+  Description
+    If true, the costmap will subscribe to PolygonStamped footprint messages instead of Polygon messages. This allows the footprint to include timestamp and frame information, which can be useful for applications that need temporally-aware footprint data.
+
 :rolling_window:
 
   ============== =======


### PR DESCRIPTION
Add documentation for the new subscribe_to_stamped_footprint parameter introduced in navigation2 PR #5345. This parameter allows Costmap2DROS to choose between Polygon and PolygonStamped footprint subscribers.

Default value: false (uses Polygon for backward compatibility)
When true: subscribes to PolygonStamped footprint messages

Closes #723

Generated with [Claude Code](https://claude.ai/code)