### PR TITLE
Update theta star planner and smoother server

### DIFF
--- a/configuration/packages/configuring-smoother-server.rst
+++ b/configuration/packages/configuring-smoother-server.rst
@@ -68,17 +68,6 @@ Smoother Server Parameters
   Description
     List of plugin names to use, also matches action server names.
 
-:introspection_mode:
-
-  ============== =============================
-  Type           Default
-  -------------- -----------------------------
-  string         "disabled"
-  ============== =============================
-
-  Description
-    The introspection mode for services and actions. Options are "disabled", "metadata", "contents".
-
   Note
     Each plugin namespace defined in this list needs to have a :code:`plugin` parameter defining the type of plugin to be loaded in the namespace.
 
@@ -95,6 +84,17 @@ Smoother Server Parameters
               plugin: "nav2_smoother::SimpleSmoother"
 
     ..
+
+:introspection_mode:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  string         "disabled"
+  ============== =============================
+
+  Description
+    The introspection mode for services and actions. Options are "disabled", "metadata", "contents".
 
 :bond_heartbeat_period:
 

--- a/configuration/packages/configuring-thetastar.rst
+++ b/configuration/packages/configuring-thetastar.rst
@@ -122,4 +122,3 @@ Example
         how_many_corners: 8
         w_euc_cost: 1.0
         w_traversal_cost: 2.0
-        w_heuristic_cost: 1.0


### PR DESCRIPTION
As noted in https://github.com/ros-navigation/navigation2/blob/ee2d7789e70a968e6194af08030b425f3c591084/nav2_theta_star_planner/README.md?plain=1#L77
heuristic cost is an internal setting that is not user changeable, I don't think it is necessary to put it in the example