### PR TITLE
Remove use_sim_time from yaml

### DIFF
--- a/configuration/packages/configuring-bt-navigator.rst
+++ b/configuration/packages/configuring-bt-navigator.rst
@@ -224,17 +224,6 @@ Parameters
   Description
     Blackboard variable to get the statuses of waypoints from the behavior tree for ``NavigateThroughPoses`` feedback/result. Should match ports of BT XML file.
 
-:use_sim_time:
-
-  ==== =======
-  Type Default
-  ---- -------
-  bool false
-  ==== =======
-
-  Description
-    Use time provided by simulation.
-
 :error_code_name_prefixes:
 
   ============== ===========================
@@ -348,7 +337,6 @@ Example
 
     bt_navigator:
       ros__parameters:
-        use_sim_time: true
         global_frame: map
         robot_base_frame: base_link
         transform_tolerance: 0.1

--- a/configuration/packages/configuring-constrained-smoother.rst
+++ b/configuration/packages/configuring-constrained-smoother.rst
@@ -258,7 +258,6 @@ Example
 
   smoother_server:
     ros__parameters:
-      use_sim_time: True
       smoother_plugins: ["SmoothPath"]
 
       SmoothPath:

--- a/configuration/packages/configuring-controller-server.rst
+++ b/configuration/packages/configuring-controller-server.rst
@@ -282,7 +282,6 @@ Example
 
     controller_server:
       ros__parameters:
-        use_sim_time: True
         controller_frequency: 20.0
         costmap_update_timeout: 0.3
         min_x_velocity_threshold: 0.001

--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -406,7 +406,6 @@ Example
           publish_frequency: 1.0
           global_frame: map
           robot_base_frame: base_link
-          use_sim_time: True
           robot_radius: 0.22 # radius set and used, so no footprint points
           resolution: 0.05
           plugins: ["static_layer", "obstacle_layer", "voxel_layer", "inflation_layer"]
@@ -478,7 +477,6 @@ Example
           publish_frequency: 2.0
           global_frame: odom
           robot_base_frame: base_link
-          use_sim_time: True
           rolling_window: true
           width: 3
           height: 3

--- a/configuration/packages/configuring-dwb-controller.rst
+++ b/configuration/packages/configuring-dwb-controller.rst
@@ -59,7 +59,6 @@ Example
     controller_server:
       ros__parameters:
         # controller server parameters (see Controller Server for more info)
-        use_sim_time: True
         controller_frequency: 20.0
         min_x_velocity_threshold: 0.001
         min_y_velocity_threshold: 0.5

--- a/configuration/packages/configuring-graceful-motion-controller.rst
+++ b/configuration/packages/configuring-graceful-motion-controller.rst
@@ -251,7 +251,6 @@ Example
 
   controller_server:
     ros__parameters:
-      use_sim_time: True
       controller_frequency: 20.0
       min_x_velocity_threshold: 0.001
       min_y_velocity_threshold: 0.5

--- a/configuration/packages/configuring-regulated-pp.rst
+++ b/configuration/packages/configuring-regulated-pp.rst
@@ -373,7 +373,6 @@ Example
 
   controller_server:
     ros__parameters:
-      use_sim_time: True
       controller_frequency: 20.0
       min_x_velocity_threshold: 0.001
       min_y_velocity_threshold: 0.5

--- a/configuration/packages/configuring-rotation-shim-controller.rst
+++ b/configuration/packages/configuring-rotation-shim-controller.rst
@@ -157,7 +157,6 @@ Example
 
   controller_server:
     ros__parameters:
-      use_sim_time: True
       controller_frequency: 20.0
       min_x_velocity_threshold: 0.001
       min_y_velocity_threshold: 0.5

--- a/configuration/packages/configuring-thetastar.rst
+++ b/configuration/packages/configuring-thetastar.rst
@@ -115,7 +115,6 @@ Example
   planner_server:
     ros__parameters:
       expected_planner_frequency: 20.0
-      use_sim_time: True
       planner_plugins: ["GridBased"]
       GridBased:
         plugin: "nav2_theta_star_planner::ThetaStarPlanner" # In Iron and older versions, "/" was used instead of "::"

--- a/configuration/packages/smac/configuring-smac-2d.rst
+++ b/configuration/packages/smac/configuring-smac-2d.rst
@@ -187,7 +187,6 @@ Example
   planner_server:
     ros__parameters:
       planner_plugins: ["GridBased"]
-      use_sim_time: True
 
       GridBased:
         plugin: "nav2_smac_planner::SmacPlanner2D" # In Iron and older versions, "/" was used instead of "::"

--- a/configuration/packages/smac/configuring-smac-hybrid.rst
+++ b/configuration/packages/smac/configuring-smac-hybrid.rst
@@ -418,7 +418,6 @@ Example
   planner_server:
     ros__parameters:
       planner_plugins: ["GridBased"]
-      use_sim_time: True
 
       GridBased:
         plugin: "nav2_smac_planner::SmacPlannerHybrid" # In Iron and older versions, "/" was used instead of "::"

--- a/configuration/packages/smac/configuring-smac-lattice.rst
+++ b/configuration/packages/smac/configuring-smac-lattice.rst
@@ -368,7 +368,6 @@ Example
   planner_server:
     ros__parameters:
       planner_plugins: ["GridBased"]
-      use_sim_time: True
 
       GridBased:
         plugin: "nav2_smac_planner::SmacPlannerLattice" # In Iron and older versions, "/" was used instead of "::"

--- a/plugin_tutorials/docs/writing_new_behavior_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_behavior_plugin.rst
@@ -219,7 +219,6 @@ To enable the plugin, we need to modify the ``nav2_params.yaml`` file as below t
       global_frame: odom
       robot_base_frame: base_link
       transform_timeout: 0.1
-      use_sim_time: true
       simulate_ahead_time: 2.0
       max_rotational_vel: 1.0
       min_rotational_vel: 0.4
@@ -254,7 +253,6 @@ with
       global_frame: odom
       robot_base_frame: base_link
       transform_timeout: 0.1
-      use_sim_time: true
       simulate_ahead_time: 2.0
       max_rotational_vel: 1.0
       min_rotational_vel: 0.4

--- a/plugin_tutorials/docs/writing_new_bt_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_bt_plugin.rst
@@ -190,7 +190,6 @@ In order for the BT Navigator node to discover the plugin we've just registered,
 
   bt_navigator:
     ros__parameters:
-      use_sim_time: True
       global_frame: map
       robot_base_frame: base_link
       odom_topic: /odom

--- a/plugin_tutorials/docs/writing_new_costmap2d_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_costmap2d_plugin.rst
@@ -203,7 +203,6 @@ For example:
   @@ -171,8 +171,8 @@ global_costmap:
          robot_base_frame: base_link
          global_frame: map
-         use_sim_time: True
   -      plugins: ["static_layer", "obstacle_layer", "voxel_layer", "inflation_layer"]
   +      plugins: ["static_layer", "obstacle_layer", "voxel_layer", "gradient_layer"]
          robot_radius: 0.22

--- a/plugin_tutorials/docs/writing_new_nav2planner_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_nav2planner_plugin.rst
@@ -199,7 +199,6 @@ To enable the plugin, we need to modify the ``nav2_params.yaml`` file as below t
   planner_server:
     ros__parameters:
       plugins: ["GridBased"]
-      use_sim_time: True
       GridBased:
         plugin: "nav2_navfn_planner::NavfnPlanner" # For Foxy and later. In Iron and older versions, "/" was used instead of "::"
         tolerance: 2.0
@@ -213,7 +212,6 @@ with
   planner_server:
     ros__parameters:
       plugins: ["GridBased"]
-      use_sim_time: True
       GridBased:
         plugin: "nav2_straightline_planner::StraightLine"
         interpolation_resolution: 0.1

--- a/plugin_tutorials/docs/writing_new_navigator_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_navigator_plugin.rst
@@ -321,7 +321,6 @@ To enable the plugin, we need to modify the ``nav2_params.yaml`` file as below
 
     bt_navigator:
       ros__parameters:
-        use_sim_time: true
         global_frame: map
         robot_base_frame: base_link
         transform_tolerance: 0.1

--- a/setup_guides/footprint/setup_footprint.rst
+++ b/setup_guides/footprint/setup_footprint.rst
@@ -46,7 +46,6 @@ For the global costmap, we have already set the ``robot_radius`` parameter to cr
 .. code-block:: yaml
   :lineno-start: 232
 
-  use_sim_time: True
   robot_radius: 0.3
   resolution: 0.05
 

--- a/setup_guides/sensors/mapping_localization.rst
+++ b/setup_guides/sensors/mapping_localization.rst
@@ -39,7 +39,6 @@ In this subsection, we will show an example configuration of ``nav2_costmap_2d``
         publish_frequency: 1.0
         global_frame: map
         robot_base_frame: base_link
-        use_sim_time: True
         robot_radius: 0.22
         resolution: 0.05
         track_unknown_space: false
@@ -75,7 +74,6 @@ In this subsection, we will show an example configuration of ``nav2_costmap_2d``
         publish_frequency: 2.0
         global_frame: odom
         robot_base_frame: base_link
-        use_sim_time: True
         rolling_window: true
         width: 3
         height: 3

--- a/tutorials/docs/navigation2_with_keepout_filter.rst
+++ b/tutorials/docs/navigation2_with_keepout_filter.rst
@@ -249,7 +249,6 @@ where the ``params_file`` variable should be set to a YAML-file having ROS param
 
   costmap_filter_info_server:
     ros__parameters:
-      use_sim_time: true
       type: 0
       filter_info_topic: "/costmap_filter_info"
       mask_topic: "/keepout_filter_mask"
@@ -257,7 +256,6 @@ where the ``params_file`` variable should be set to a YAML-file having ROS param
       multiplier: 1.0
   filter_mask_server:
     ros__parameters:
-      use_sim_time: true
       frame_id: "map"
       topic_name: "/keepout_filter_mask"
       yaml_filename: "keepout_mask.yaml"

--- a/tutorials/docs/navigation2_with_speed_filter.rst
+++ b/tutorials/docs/navigation2_with_speed_filter.rst
@@ -216,7 +216,6 @@ where the ``params_file`` variable should be set to a YAML-file having ROS param
 
   costmap_filter_info_server:
     ros__parameters:
-      use_sim_time: true
       type: 1
       filter_info_topic: "/costmap_filter_info"
       mask_topic: "/speed_filter_mask"
@@ -224,7 +223,6 @@ where the ``params_file`` variable should be set to a YAML-file having ROS param
       multiplier: -1.0
   filter_mask_server:
     ros__parameters:
-      use_sim_time: true
       frame_id: "map"
       topic_name: "/speed_filter_mask"
       yaml_filename: "speed_mask.yaml"

--- a/tutorials/docs/navigation2_with_stvl.rst
+++ b/tutorials/docs/navigation2_with_stvl.rst
@@ -76,7 +76,6 @@ For example, the following will load the static and obstacle layer plugins into 
     global_costmap:
       global_costmap:
         ros__parameters:
-          use_sim_time: True
           plugins: ["static_layer", "obstacle_layer"]
 
 
@@ -92,7 +91,6 @@ For example, if the application required an STVL layer and no obstacle layer, ou
     global_costmap:
       global_costmap:
         ros__parameters:
-          use_sim_time: True
           plugins: ["static_layer", "stvl_layer"]
 
 Similar to the Voxel Layer, after registering the plugin, we can add the configuration of the STVL layer under the namespace ``stvl_layer``.

--- a/tutorials/docs/using_collision_monitor.rst
+++ b/tutorials/docs/using_collision_monitor.rst
@@ -79,7 +79,6 @@ The whole ``nav2_collision_monitor/params/collision_monitor_params.yaml`` file i
 
     collision_monitor:
       ros__parameters:
-        use_sim_time: True
         base_frame_id: "base_footprint"
         odom_frame_id: "odom"
         cmd_vel_in_topic: "cmd_vel_smoothed"

--- a/tutorials/docs/using_shim_controller.rst
+++ b/tutorials/docs/using_shim_controller.rst
@@ -46,7 +46,6 @@ As such, its configuration looks very similar to that of any other plugin. In th
 
     controller_server:
       ros__parameters:
-        use_sim_time: True
         controller_frequency: 20.0
         min_x_velocity_threshold: 0.001
         min_y_velocity_threshold: 0.5
@@ -88,7 +87,6 @@ There is one more remaining parameter of the ``RotationShimController`` not ment
 
     controller_server:
       ros__parameters:
-        use_sim_time: True
         controller_frequency: 20.0
         min_x_velocity_threshold: 0.001
         min_y_velocity_threshold: 0.5


### PR DESCRIPTION
I think with https://github.com/ros-navigation/navigation2/pull/3131, it is safe to remove all use_sim_time in the docs