### PR TITLE
Add missing min_obstacle_height in obstacle layer

### DIFF
--- a/configuration/packages/costmap-plugins/obstacle.rst
+++ b/configuration/packages/costmap-plugins/obstacle.rst
@@ -31,6 +31,17 @@ This costmap layer implements a plugin that uses 2D raycasting for 2D lidars, de
   Description
     Clear any occupied cells under robot footprint.
 
+:``<obstacle layer>``.min_obstacle_height:
+
+  ====== =======
+  Type   Default
+  ------ -------
+  double 0.0
+  ====== =======
+
+  Description
+    Minimum height to add return to occupancy grid.
+
 :``<obstacle layer>``.max_obstacle_height:
 
   ====== =======


### PR DESCRIPTION
min_obstacle_height here https://github.com/ros-navigation/navigation2/blob/27dab69edfd05f8e2c6d77d232c008a92fd5b5f5/nav2_costmap_2d/plugins/obstacle_layer.cpp#L98 is not documented 

I am also curious why does this parameter does not exist in voxel layer
https://github.com/ros-navigation/navigation2/blob/27dab69edfd05f8e2c6d77d232c008a92fd5b5f5/nav2_costmap_2d/plugins/voxel_layer.cpp#L197