### PR TITLE
Rename transform_timeout as transform_tolerance in configs

### DIFF
--- a/configuration/packages/configuring-behavior-server.rst
+++ b/configuration/packages/configuring-behavior-server.rst
@@ -461,7 +461,7 @@ Example
         local_frame: odom
         global_frame: map
         robot_base_frame: base_link
-        transform_timeout: 0.1
+        transform_tolerance: 0.1
         simulate_ahead_time: 2.0
         max_rotational_vel: 1.0
         min_rotational_vel: 0.4

--- a/configuration/packages/configuring-savitzky-golay-smoother.rst
+++ b/configuration/packages/configuring-savitzky-golay-smoother.rst
@@ -61,7 +61,7 @@ Example
         costmap_topic: global_costmap/costmap_raw
         footprint_topic: global_costmap/published_footprint
         robot_base_frame: base_link
-        transform_timeout: 0.1
+        transform_tolerance: 0.1
         smoother_plugins: ["savitzky_golay_smoother"]
         savitzky_golay_smoother:
           plugin: "nav2_smoother::SavitzkyGolaySmoother"

--- a/configuration/packages/configuring-simple-smoother.rst
+++ b/configuration/packages/configuring-simple-smoother.rst
@@ -101,7 +101,7 @@ Example
         costmap_topic: global_costmap/costmap_raw
         footprint_topic: global_costmap/published_footprint
         robot_base_frame: base_link
-        transform_timeout: 0.1
+        transform_tolerance: 0.1
         smoother_plugins: ["simple_smoother"]
         simple_smoother:
           plugin: "nav2_smoother::SimpleSmoother"

--- a/configuration/packages/configuring-smoother-server.rst
+++ b/configuration/packages/configuring-smoother-server.rst
@@ -127,7 +127,7 @@ Example
         costmap_topic: global_costmap/costmap_raw
         footprint_topic: global_costmap/published_footprint
         robot_base_frame: base_link
-        transform_timeout: 0.1
+        transform_tolerance: 0.1
         smoother_plugins: ["simple_smoother"]
         simple_smoother:
           plugin: "nav2_smoother::SimpleSmoother"

--- a/plugin_tutorials/docs/writing_new_behavior_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_behavior_plugin.rst
@@ -218,7 +218,7 @@ To enable the plugin, we need to modify the ``nav2_params.yaml`` file as below t
         plugin: "nav2_behaviors::Wait" # In Iron and older versions, "/" was used instead of "::"
       global_frame: odom
       robot_base_frame: base_link
-      transform_timeout: 0.1
+      transform_tolerance: 0.1
       simulate_ahead_time: 2.0
       max_rotational_vel: 1.0
       min_rotational_vel: 0.4
@@ -252,7 +252,7 @@ with
       to_number: ... # the operations center number
       global_frame: odom
       robot_base_frame: base_link
-      transform_timeout: 0.1
+      transform_tolerance: 0.1
       simulate_ahead_time: 2.0
       max_rotational_vel: 1.0
       min_rotational_vel: 0.4

--- a/tutorials/docs/adding_smoother.rst
+++ b/tutorials/docs/adding_smoother.rst
@@ -51,7 +51,7 @@ Under each name, the parameters for that particular algorithm must be specified 
         costmap_topic: global_costmap/costmap_raw
         footprint_topic: global_costmap/published_footprint
         robot_base_frame: base_link
-        transform_timeout: 0.1
+        transform_tolerance: 0.1
         smoother_plugins: ["simple_smoother", "curvature_smoother"]
         simple_smoother:
           plugin: "nav2_smoother::SimpleSmoother"


### PR DESCRIPTION
some of the configs are still using transform_timeout, this PR replaced it with transform_tolerance to match the current version