### PR TITLE
Add pip and github actions to dependabot config.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "🐍"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "🛠️"


### PR DESCRIPTION
## Description

* Added Dependabot configuration to monitor release versions of pip packages and GitHub Actions.
* The commit message prefixes have been configured to match the configuration over at [nav2](https://github.com/ros-navigation/navigation2/blob/main/.github/dependabot.yml).