### PR TITLE
Remove all build warnings

### DIFF
--- a/behavior_trees/overview/detailed_behavior_tree_walkthrough.rst
+++ b/behavior_trees/overview/detailed_behavior_tree_walkthrough.rst
@@ -255,6 +255,7 @@ At the top level, a ``Sequence`` ensures the following steps are executed in ord
 - A ``Fallback`` node first checks whether planner or controller recoveries might help resolve the issue. If either returns ``SUCCESS``, the fallback succeeds and the sequence proceeds to the next step.
 
 - A ``ReactiveFallback`` that controls the flow between the rest of the system wide recoveries, and asynchronously checks if a new goal has been received.
+
 If at any point the goal gets updated, this subtree will halt all children and return ``SUCCESS``. This allows for quick reactions to new goals and preempt currently executing recoveries.
 This should look familiar to the contextual recovery portions of the ``Navigation`` subtree. This is a common BT pattern to handle the situation "Unless 'this condition' happens, Do action A".
 

--- a/conf.py
+++ b/conf.py
@@ -91,7 +91,7 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build','_themes','scripts', 'README.md' ]
+exclude_patterns = ['venv', '_build','_themes','scripts', 'README.md' ]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -201,4 +201,4 @@ breathe_default_project = "SOF Project"
 breathe_default_members = ('members', 'undoc-members', 'content-only')
 
 extlinks = {'projectfile':
-    ('https://github.com/ros-navigation/navigation2/blob/main/%s', 'filepath ')}
+    ('https://github.com/ros-navigation/navigation2/blob/main/%s', 'filepath %s')}

--- a/configuration/packages/bt-plugins/controls/PauseResumeController.rst
+++ b/configuration/packages/bt-plugins/controls/PauseResumeController.rst
@@ -1,7 +1,7 @@
 .. _bt_pause_resume_controller_control:
 
 PauseResumeController
-===================
+=====================
 
 Controlled through service calls to pause and resume the execution of the tree.
 It has one mandatory child for the RESUMED, and three optional for the PAUSED state, the ON_PAUSE event and the ON_RESUME event.

--- a/migration/Kilted.rst
+++ b/migration/Kilted.rst
@@ -231,4 +231,4 @@ Added PersistentSequence and PauseResumeController Control Nodes
 
 In `PR #5247 <https://github.com/ros-navigation/navigation2/pull/5247>`_ two new Nav2 specific behavior tree control nodes have been added.
 
-The ``PauseResumeController`` (`docs <../configuration/packages/bt-plugins/controls/PauseResumeController.html>`_) adds services to pause and resume execution of the tree. Related to this, the ``PersistentSequence`` (`docs <../configuration/packages/bt-plugins/controls/PersistentSequence.html>`_) control node allows the child index to be exposed to the behavior tree through a bidirectional port. This allows the sequence to be continued on resume where it was paused.
+The `PauseResumeController <../configuration/packages/bt-plugins/controls/PauseResumeController.html>`_ adds services to pause and resume execution of the tree. Related to this, the `PersistentSequence <../configuration/packages/bt-plugins/controls/PersistentSequence.html>`_ control node allows the child index to be exposed to the behavior tree through a bidirectional port. This allows the sequence to be continued on resume where it was paused.

--- a/plugins/index.rst
+++ b/plugins/index.rst
@@ -600,9 +600,10 @@ Behavior Tree Nodes
 .. _Is Path Valid Condition: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/is_path_valid_condition.cpp
 .. _Path Expiring Timer: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/path_expiring_timer_condition.cpp
 .. _Are Error Codes Present: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/are_error_codes_present_condition.cpp
-.. _Would A Controller Recovery Help: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help.cpp
-.. _Would A Planner Recovery Help: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help.cpp
-.. _Would A Smoother Recovery Help: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help.cpp
+.. _Would A Controller Recovery Help: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/would_a_controller_recovery_help_condition.cpp
+.. _Would A Planner Recovery Help: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/would_a_planner_recovery_help_condition.cpp
+.. _Would A Smoother Recovery Help: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/would_a_smoother_recovery_help_condition.cpp
+.. _Would A Route Recovery Help: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/would_a_route_recovery_help_condition.cpp
 .. _Is Battery Charging Condition: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/is_battery_charging_condition.cpp
 .. _Are Poses Near Condition: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/condition/are_poses_near_condition.cpp
 

--- a/tutorials/docs/navigation2_with_gps.rst
+++ b/tutorials/docs/navigation2_with_gps.rst
@@ -96,7 +96,7 @@ Tutorial Steps
 0- Setup Gazebo World
 ---------------------
 
-To navigate using GPS we first need to create an outdoors Gazebo world with a robot having a GPS sensor to setup for navigation. For this tutorial we will be using the `Sonoma Raceway <https://app.gazebosim.org/OpenRobotics/fuel/models/Sonoma%20Raceway>`_ because its aligned with the real location. A sample world has been setup `here <https://github.com/ros-navigation/navigation2_tutorials/tree/master/nav2_gps_waypoint_follower_demo/worlds/tb3_sonoma_raceway.sdf.xacro>`_ using gazebo's navsat and  spherical coordinates plugin, which creates a local tangent plane centered in the set geographic origin and provides latitude, longitude and altitude coordinates for each point in the world:
+To navigate using GPS we first need to create an outdoors Gazebo world with a robot having a GPS sensor to setup for navigation. For this tutorial we will be using the `Sonoma Raceway <https://app.gazebosim.org/OpenRobotics/fuel/models/Sonoma%20Raceway>`_ because its aligned with the real location. A sample `world <https://github.com/ros-navigation/navigation2_tutorials/tree/master/nav2_gps_waypoint_follower_demo/worlds/tb3_sonoma_raceway.sdf.xacro>`_ has been setup using gazebo's navsat and spherical coordinates plugin, which creates a local tangent plane centered in the set geographic origin and provides latitude, longitude and altitude coordinates for each point in the world:
 
 .. code-block:: xml
 
@@ -121,7 +121,7 @@ To get GPS readings from Gazebo, we also need to modify the xacro and urdf for t
 
 The changes that was done in xacro file ``gz_waffle_gps.sdf.xacro`` was to include the ``gps_link`` that includes the navsat sensor. In addition we create a joint for this link that publishes a static transform w.r.t. ``base_link``.
 
-.. code-block:: xacro
+.. code-block:: xml
 
   <link name="gps_link">
     <sensor name="navsat" type="navsat">
@@ -150,7 +150,7 @@ The changes that was done in xacro file ``gz_waffle_gps.sdf.xacro`` was to inclu
 
 Additionally, the joint needs to be defined again in the urdf file ``turtlebot3_waffle_gps.urdf``
 
-.. code-block:: urdf
+.. code-block:: xml
 
    <joint name="gps_joint" type="fixed">
     <parent link="base_link"/>
@@ -159,7 +159,7 @@ Additionally, the joint needs to be defined again in the urdf file ``turtlebot3_
   </joint>
   <link name="gps_link"/>
 
-In addition you need to include the gps topic in your gazebo to ros bridge file, an example of this can be found in the ``turtlebot3_waffle_gps_bridge.yaml`` in the `nav2_minimal_turtlebot_simulation repo <https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation/blob/main/nav2_minimal_tb3_sim/config/turtlebot3_waffle_gps_bridge.yaml>`_
+In addition you need to include the gps topic in your gazebo to ros bridge file, an example of this can be found in the ``turtlebot3_waffle_gps_bridge.yaml`` in the `nav2_minimal_turtlebot_simulation <https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation/blob/main/nav2_minimal_tb3_sim/config/turtlebot3_waffle_gps_bridge.yaml>`_ repository.
 
 .. code-block:: yaml
 
@@ -287,7 +287,7 @@ On a different terminal launch mapviz using the pre-built `config file <https://
 
 * Stadiamaps: This would require an api key, see `Get a stadiamap Api key  <https://docs.stadiamaps.com/static-maps/>`_ . Modify the config file as follows:
 
-.. code-block:: yml
+.. code-block:: yaml
 
   - type: mapviz_plugins/tile_map
     name: new display


### PR DESCRIPTION
## Description

All the build warnings are fixed in this contribution:

* Ignore the `venv` directory during the build process.
   ```bash
   /home/leander/codes/docs.nav2.org/venv/lib/python3.12/site-packages/idna-3.10.dist-info/LICENSE.md: WARNING: document isn't included in any toctree
   ```
* Fix the caption string of external links.
   ```bash
   WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
   ```

* Added correct paths to the links of the plugins specified.
   ```bash
   /home/leander/codes/docs.nav2.org/plugins/index.rst:578: ERROR: Unknown target name: "would a route recovery help".
   ```

* Added `xml` formatting instead of `xacro` or `urdf` as they have no inbuilt `rst` formatting support.
   ```bash
   /home/leander/codes/docs.nav2.org/tutorials/docs/navigation2_with_gps.rst:124: WARNING: Pygments lexer name 'xacro' is not known
   ```

* Renamed conflicting hyperlinks having the same target to fix build warnings.
   ```bash
   /home/leander/codes/docs.nav2.org/tutorials/docs/navigation2_with_gps.rst:4: WARNING: Duplicate explicit target name: "nav2_minimal_turtlebot_simulation repo".
   ```

## Testing
The following changes have been verified using `make html` and opening the `_build/html/index.html` file in a browser window.