### PR TITLE
Toggle collision manager docs

### DIFF
--- a/configuration/packages/bt-plugins/actions/ToggleCollisionMonitor.rst
+++ b/configuration/packages/bt-plugins/actions/ToggleCollisionMonitor.rst
@@ -1,0 +1,50 @@
+.. _bt_toggle_colllsion_monitor_service:
+
+
+ToggleCollisionMonitor
+======================
+
+Calls the ToggleCollisionMonitor serice. Used to toggle the collision monitor on (enabled) and off (disabled).
+
+Input Ports
+-----------
+
+:enable:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  bool           true
+  ============== =======
+
+  Description
+    	Wether to enable or disable the collision monitor.
+
+:service_name:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  string         N/A
+  ============== =======
+
+  Description
+    	Service name.
+
+:server_timeout:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  double         10
+  ============== =======
+
+  Description
+    	Server timeout (ms).
+
+Example
+-------
+
+.. code-block:: xml
+
+  <ToggleCollisionMonitor enable="false" service_name="collision_monitor/toggle_collision_monitor"/>

--- a/configuration/packages/configuring-bt-navigator.rst
+++ b/configuration/packages/configuring-bt-navigator.rst
@@ -238,11 +238,11 @@ Parameters
 
 :bt_search_directories:
 
-  ============== =================================================
+  ============== ==================================================
   Type           Default
-  -------------- -----------------------------
+  -------------- --------------------------------------------------
   vector<string> $(find-pkg-share nav2_bt_navigator)/behavior_trees
-  ============== =================================================
+  ============== ==================================================
 
   Description
     List of directories that hosts behavior trees XML files. It is needed to register all behavior trees as well as subtrees.

--- a/configuration/packages/configuring-bt-xml.rst
+++ b/configuration/packages/configuring-bt-xml.rst
@@ -63,6 +63,7 @@ Action Plugins
   bt-plugins/actions/AppendGoalPoseToGoals.rst
   bt-plugins/actions/ExtractRouteNodesAsGoals.rst
   bt-plugins/actions/GetNextFewGoals.rst
+  bt-plugins/actions/ToggleCollisionMonitor.rst
 
 Condition Plugins
 *****************

--- a/migration/Kilted.rst
+++ b/migration/Kilted.rst
@@ -390,3 +390,34 @@ adding virtual obstacles on maps, dynamic objects simulation/highlighting, hidin
 To run Vector Object server a new ``vector_object_server.launch.py`` launch-file is being supplied.
 :ref:`navigation2_with_vector_objects` tutorial explains how launch Vector Object server and navigate with vector objects added to raster costmaps.
 The information about Vector Object server parameters set-up could be found at :ref:`configuring_vector_object_server` configuration guide.
+
+
+Toggle collision monitor service and BT plugin
+----------------------------------------------
+
+`PR #5493 <https://github.com/ros-navigation/navigation2/pull/5493>`_ and `PR #5532 <https://github.com/ros-navigation/navigation2/pull/5532>`_ introduce a new toggle service for the collision monitor.  
+This service allows enabling or disabling all collision monitor polygons while keeping sensor checks within the collision monitor active.
+
+The service is defined using a new interface, ``Toggle.srv``:
+
+.. code-block:: text
+
+   bool enable
+   ---
+   bool success
+   string message
+
+This interface can be extended in the future if needed.
+
+A corresponding Behavior Tree (BT) plugin was also created to call this service.  
+The plugin is based on ``BtServiceNode`` and provides the following input ports:
+
+- ``service_name``: name of the toggle service  
+- ``server_timeout``: timeout for service calls  
+- ``enable``: boolean flag to enable or disable the collision monitor  
+
+An example usage in a Behavior Tree XML file:
+
+.. code-block:: xml
+
+   <ToggleCollisionMonitor enable="false" service_name="collision_monitor/toggle_collision_monitor"/>

--- a/plugins/index.rst
+++ b/plugins/index.rst
@@ -457,6 +457,8 @@ Behavior Tree Nodes
 +---------------------------------------------+---------------------+------------------------------------------+
 | `Get Next Few Goals Action`_                | Steve Macenski      | Obtains the next N goals in a goal vector|
 +---------------------------------------------+---------------------+------------------------------------------+
+| `Toggle Collision Monitor Service`_         | David Grbac         | Calls toggle collision monitor service   |
++---------------------------------------------+---------------------+------------------------------------------+
 
 .. _Back Up Action: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/action/back_up_action.cpp
 .. _Drive On Heading Action: https://github.com/ros-navigation/navigation2/tree/main/nav2_behavior_tree/plugins/action/drive_on_heading_action.cpp
@@ -501,6 +503,7 @@ Behavior Tree Nodes
 .. _Append Goal Pose To Goals Action: https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/plugins/action/append_goal_pose_to_goals_action.cpp
 .. _Extract Route Nodes To Goals Action: https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/plugins/action/extract_route_nodes_as_goals_action.cpp
 .. _Get Next Few Goals Action: https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/plugins/action/get_next_few_goals_action.cpp
+.. _Toggle Collision Monitor Service: https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/plugins/action/get_next_few_goals_action.cpp
 
 
 +------------------------------------+--------------------+------------------------+

--- a/plugins/index.rst
+++ b/plugins/index.rst
@@ -503,7 +503,7 @@ Behavior Tree Nodes
 .. _Append Goal Pose To Goals Action: https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/plugins/action/append_goal_pose_to_goals_action.cpp
 .. _Extract Route Nodes To Goals Action: https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/plugins/action/extract_route_nodes_as_goals_action.cpp
 .. _Get Next Few Goals Action: https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/plugins/action/get_next_few_goals_action.cpp
-.. _Toggle Collision Monitor Service: https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/plugins/action/get_next_few_goals_action.cpp
+.. _Toggle Collision Monitor Service: https://github.com/ros-navigation/navigation2/blob/main/nav2_behavior_tree/plugins/action/toggle_collision_monitor_service.cpp
 
 
 +------------------------------------+--------------------+------------------------+


### PR DESCRIPTION
Adresses ros-navigation/navigation2#5493 and ros-navigation/navigation2#5532 

Documents the addition of the toggle service for the collision monitor and the BT plugin for it.

- Added to the Configuration guide -> Behavior tree XML nodes -> Action plugin list
- Added ToggleCollisionMonitor.rst
- Added to Navigation plugins behavior tree nodes list
- Added to Migration guide