### PR TITLE
Fix default service name for toggle collision monitor

### DIFF
--- a/configuration/packages/bt-plugins/actions/ToggleCollisionMonitor.rst
+++ b/configuration/packages/bt-plugins/actions/ToggleCollisionMonitor.rst
@@ -47,4 +47,4 @@ Example
 
 .. code-block:: xml
 
-  <ToggleCollisionMonitor enable="false" service_name="collision_monitor/toggle_collision_monitor"/>
+  <ToggleCollisionMonitor enable="false" service_name="collision_monitor/toggle"/>

--- a/migration/Kilted.rst
+++ b/migration/Kilted.rst
@@ -420,4 +420,4 @@ An example usage in a Behavior Tree XML file:
 
 .. code-block:: xml
 
-   <ToggleCollisionMonitor enable="false" service_name="collision_monitor/toggle_collision_monitor"/>
+   <ToggleCollisionMonitor enable="false" service_name="collision_monitor/toggle"/>


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

Fix default service name for toggle collision monitor.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #780 |
| Does this PR contain AI-generated software? | No |
---

## Description of contribution in a few bullet points

Change the default service name :=)

<!--
* Updated the documentation to reflect corresponding changes in navigation2.
* Reorganised some sections for better clarity.
-->
