### PR TITLE
docs: migrate bond traffic to per-server topics (#6061 / navigation2#6309)

### DIFF
--- a/migration/Kilted.rst
+++ b/migration/Kilted.rst
@@ -645,20 +645,6 @@ This removes O(N²) DDS fan-out when many managed servers are bonded: each
 heartbeat is delivered only to the matching manager/server pair instead of to
 every Bond subscription on a shared topic.
 
-**Migration notes** (atomic upgrade required):
-
-* Upgrade the lifecycle manager and all managed Nav2 servers together. Mixed
-  old/new binaries cannot form bonds because they publish and subscribe on
-  different topics.
-* Launch remappings that targeted the old shared ``bond`` topic no longer apply.
-  Remap ``bond/<server_name>`` (or a pattern that covers ``bond/*``) instead.
-* Monitoring and diagnostic tools that subscribed to ``/bond`` (or a namespaced
-  ``bond``) must subscribe to ``bond/<server_name>`` for each server, or to
-  ``bond/*`` if your tooling supports wildcards.
-* Under a non-empty ROS namespace, relative topics resolve as before
-  (for example ``/robot/bond/controller_server`` when both peers are in
-  ``/robot``).
-
 Centralize Path Handler logic in Controller Server
 --------------------------------------------------
 

--- a/migration/Kilted.rst
+++ b/migration/Kilted.rst
@@ -632,6 +632,33 @@ The following table shows the performance impact of changing the bond heartbeat 
 
 *Note: This table should be populated with data from issue #5784 comment. Composed CPU is for all Nav2 processes combined.*
 
+Per-Server Bond Topics
+----------------------
+
+`PR #6309 <https://github.com/ros-navigation/navigation2/pull/6309>`_ changes
+lifecycle bond heartbeats from a single shared ``bond`` topic to a per-server
+topic ``bond/<server_name>`` (for example ``bond/controller_server``).
+Both ``nav2::LifecycleNode::createBond()`` and the lifecycle manager use
+``nav2::bond_topic_name()`` so peers stay aligned when they share a namespace.
+
+This removes O(N²) DDS fan-out when many managed servers are bonded: each
+heartbeat is delivered only to the matching manager/server pair instead of to
+every Bond subscription on a shared topic.
+
+**Migration notes** (atomic upgrade required):
+
+* Upgrade the lifecycle manager and all managed Nav2 servers together. Mixed
+  old/new binaries cannot form bonds because they publish and subscribe on
+  different topics.
+* Launch remappings that targeted the old shared ``bond`` topic no longer apply.
+  Remap ``bond/<server_name>`` (or a pattern that covers ``bond/*``) instead.
+* Monitoring and diagnostic tools that subscribed to ``/bond`` (or a namespaced
+  ``bond``) must subscribe to ``bond/<server_name>`` for each server, or to
+  ``bond/*`` if your tooling supports wildcards.
+* Under a non-empty ROS namespace, relative topics resolve as before
+  (for example ``/robot/bond/controller_server`` when both peers are in
+  ``/robot``).
+
 Centralize Path Handler logic in Controller Server
 --------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add a Kilted→L-turtle migration section for per-server lifecycle bond topics introduced in ros-navigation/navigation2#6309.
- Covers atomic upgrade, remapping/monitoring impact, and namespaced topic resolution.

## Companion
- Implementation PR: https://github.com/ros-navigation/navigation2/pull/6309
- Issue: https://github.com/ros-navigation/navigation2/issues/6061

## Test plan
- [ ] Confirm section renders under Migration Guides → Kilted
- [ ] Spot-check links to navigation2#6309