### PR TITLE
style(sidebar): expand sponsorship banner on specific pages

### DIFF
--- a/docs/about_and_contact/index.md
+++ b/docs/about_and_contact/index.md
@@ -1,4 +1,5 @@
 ---
+expand_sponsorship_banner: true
 edit_uri: https://github.com/ros-navigation/docs.nav2.org/tree/rolling/docs/
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 expand_sidebar_nav: true
+expand_sponsorship_banner: true
 edit_uri: https://github.com/ros-navigation/docs.nav2.org/tree/rolling/docs/
 ---
 

--- a/docs/robots_using/index.md
+++ b/docs/robots_using/index.md
@@ -1,4 +1,5 @@
 ---
+expand_sponsorship_banner: true
 edit_uri: https://github.com/ros-navigation/docs.nav2.org/tree/rolling/docs/
 ---
 

--- a/overrides/assets/stylesheets/sponsorship_banner.css
+++ b/overrides/assets/stylesheets/sponsorship_banner.css
@@ -28,6 +28,10 @@
     }
   }
 
+  .sponsorship-banner-logo {
+    display: none;
+  }
+
   .sponsorship-banner-button {
     color:white;
     background: var(--color-nav2-blue);
@@ -44,11 +48,12 @@
     }
   }
 
-  .sponsorship-banner-button--fallback {
-    display: none;
-  }
+}
 
-  .sponsorship-expanded-banner-logo {
+.sidebar-banner--expanded {
+
+  .sponsorship-banner-logo {
+    display: block;
     width: 10rem;
     margin: 0.8rem 0 0.5rem;
 
@@ -58,35 +63,18 @@
     @media screen and (min-height: 670px) and (max-height: 739px) {
       width: 6rem;
     }
-  }
-
-  @media screen and (max-height: 669px) {
-    .sponsorship-expanded-banner-logo {
+    @media screen and (max-height: 669px) {
       display: none;
-    }
-
-    .sponsorship-expanded-banner-button {
-      display: none;
-    }
-
-    .sponsorship-banner-button--fallback {
-      display: inline-block;
     }
   }
 
-  .sponsorship-expanded-banner-button {
-    color:white;
-    background: var(--color-nav2-blue);
+  .sponsorship-banner-button {
     padding: 0.5rem 1.6rem;
-    border-radius: 0.3rem;
-    text-decoration: none;
-    font-weight: bold;
     font-size: 0.76rem;
-    text-align: center;
 
-    &:hover {
-      color: white;
-      background: var(--color-nav2-light-blue);
+    @media screen and (max-height: 669px) {
+      padding: 0.4rem 0.8rem;
+      font-size: 0.65rem;
     }
   }
 }

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -102,39 +102,33 @@
 
       {% set first = page.toc | first %}
       {% set has_toc = first and first.children %}
-      {% if not has_toc or (page.meta and page.meta.expand_sponsorship_banner) %}
-
-        <!-- Add expanded sponsorship banner instead of Table of Contents -->
-        <div class="sidebar-banner">
-          <span class="sponsorship-banner">
-            <h3>Partner with Nav2</h3> Sponsorship opportunities &amp; professional services available.
-          </span>
+      {% set show_expanded = not has_toc or (page.meta and page.meta.expand_sponsorship_banner) %}
+      
+      <div class="sidebar-banner">
+        <span class="sponsorship-banner">
+          <h3>Partner with Nav2</h3> Sponsorship opportunities &amp; professional services available.
+        </span>
+        {% if show_expanded %}
+          <!-- Add expanded sponsorship banner instead of Table of Contents -->
           <img class="sponsorship-expanded-banner-logo" src="{{ 'assets/nav2_logo_powered_gray_text.png' | url }}"/>
           <a class="sponsorship-expanded-banner-button" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
           <a class="sponsorship-banner-button sponsorship-banner-button--fallback" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
-        </div>
+        {% else %}
+          <!-- Add collapsed sponsorship banner above Table of Contents -->
+          <a class="sponsorship-banner-button" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
+        {% endif %}
+      </div>
 
+      {% if show_expanded %}
         <!-- Dummy wrapper for Table of Contents -->
         <!-- Needed for correct sidebar generation -->
-        <div class="md-sidebar__scrollwrap md-sidebar__scrollwrap--empty">
-        </div>
-
+        <div class="md-sidebar__scrollwrap md-sidebar__scrollwrap--empty"></div>
       {% else %}
-
-        <!-- Add collapsed sponsorship banner above Table of Contents -->
-        <div class="sidebar-banner">
-          <span class="sponsorship-banner">
-            <h3>Partner with Nav2</h3> Sponsorship opportunities &amp; professional services available.
-          </span>
-          <a class="sponsorship-banner-button" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
-        </div>
-
         <div class="md-sidebar__scrollwrap">
           <div class="md-sidebar__inner">
             {% include "partials/toc.html" %}
           </div>
         </div>
-
       {% endif %}
 
     </div>

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -102,24 +102,9 @@
 
       {% set first = page.toc | first %}
       {% set has_toc = first and first.children %}
-      {% if has_toc %}
+      {% if not has_toc or (page.meta and page.meta.expand_sponsorship_banner) %}
 
-        <!-- Add sponsorship banner above the Table of Contents -->
-        <div class="sidebar-banner">
-          <span class="sponsorship-banner">
-            <h3>Partner with Nav2</h3> Sponsorship opportunities &amp; professional services available.
-          </span>
-          <a class="sponsorship-banner-button" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
-        </div>
-
-        <div class="md-sidebar__scrollwrap">
-          <div class="md-sidebar__inner">
-            {% include "partials/toc.html" %}
-          </div>
-        </div>
-
-      {% else %}
-
+        <!-- Add expanded sponsorship banner instead of Table of Contents -->
         <div class="sidebar-banner">
           <span class="sponsorship-banner">
             <h3>Partner with Nav2</h3> Sponsorship opportunities &amp; professional services available.
@@ -132,6 +117,22 @@
         <!-- Dummy wrapper for Table of Contents -->
         <!-- Needed for correct sidebar generation -->
         <div class="md-sidebar__scrollwrap md-sidebar__scrollwrap--empty">
+        </div>
+
+      {% else %}
+
+        <!-- Add collapsed sponsorship banner above Table of Contents -->
+        <div class="sidebar-banner">
+          <span class="sponsorship-banner">
+            <h3>Partner with Nav2</h3> Sponsorship opportunities &amp; professional services available.
+          </span>
+          <a class="sponsorship-banner-button" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
+        </div>
+
+        <div class="md-sidebar__scrollwrap">
+          <div class="md-sidebar__inner">
+            {% include "partials/toc.html" %}
+          </div>
         </div>
 
       {% endif %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -100,38 +100,25 @@
     {% endif %}
     <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc" {{ hidden }}>
 
+      <!-- Sponsorship banner -->
+      <!-- Display expanded version if toc is not present or expand_sponsorship_banner metadata property is set -->
       {% set first = page.toc | first %}
       {% set has_toc = first and first.children %}
       {% set show_expanded = not has_toc or (page.meta and page.meta.expand_sponsorship_banner) %}
-      
-      <div class="sidebar-banner">
+      <div class="sidebar-banner {% if show_expanded %}sidebar-banner--expanded{% endif %}">
         <span class="sponsorship-banner">
           <h3>Partner with Nav2</h3> Sponsorship opportunities &amp; professional services available.
         </span>
-        {% if show_expanded %}
-          <!-- Add expanded sponsorship banner instead of Table of Contents -->
-          <img class="sponsorship-expanded-banner-logo" src="{{ 'assets/nav2_logo_powered_gray_text.png' | url }}"/>
-          <a class="sponsorship-expanded-banner-button" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
-          <a class="sponsorship-banner-button sponsorship-banner-button--fallback" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
-        {% else %}
-          <!-- Add collapsed sponsorship banner above Table of Contents -->
-          <a class="sponsorship-banner-button" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
-        {% endif %}
+        <img class="sponsorship-banner-logo" src="{{ 'assets/nav2_logo_powered_gray_text.png' | url }}" alt="Nav2 Logo"/>
+        <a class="sponsorship-banner-button" href="https://opennav.org" target="_blank" rel="noopener">Learn More</a>
       </div>
-
-      {% if show_expanded %}
-        <!-- Dummy wrapper for Table of Contents -->
-        <!-- Needed for correct sidebar generation -->
-        <div class="md-sidebar__scrollwrap md-sidebar__scrollwrap--empty"></div>
-      {% else %}
-        <div class="md-sidebar__scrollwrap">
-          <div class="md-sidebar__inner">
-            {% include "partials/toc.html" %}
-          </div>
+      <div class="md-sidebar__scrollwrap {% if show_expanded %}md-sidebar__scrollwrap--empty{% endif %}">
+        <div class="md-sidebar__inner">
+          {% include "partials/toc.html" %}
         </div>
-      {% endif %}
-
+      </div>
     </div>
+
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Does this PR contain AI-generated software? | No |
---

## Description of contribution in a few bullet points

- Added custom metadata property that allows expanding the sponsorship banner on specific pages. The banner will now be displayed by default on pages without a table of contents or when the property is set:
  ```
  ---
  expand_sponsorship_banner: true
  ---
  ```
- Displayed a full-size banner on the main index pages:
  - Home
  - Robots Using
  - About & Contact
  
  Note: The banner hides their tables of contents.
  On other main pages, the banner is expanded by default.


- Simplified logic for display conditions.
